### PR TITLE
Add configuration options for initializing the ARYTHMATIK module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ section of the Arduino Sketch Specification.
 git submodule add https://github.com/awonak/libmodulove.git <sketch>/src/libmodulove
 ```
 
+**Supported build flags.**
+
+`ENCODER_REVERSED` - Reverse the direction of the rotary encoder.
+
+`ROTATE_PANEL` - Rotate the orientation of the OLED by 180 degrees and swap the CLK and RST input jacks.
+
 **Download the latest release.**
 
 [TODO]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ git submodule add https://github.com/awonak/libmodulove.git <sketch>/src/libmodu
 
 `ROTATE_PANEL` - Rotate the orientation of the OLED by 180 degrees and swap the CLK and RST input jacks.
 
+Example usage:
+
+```shell
+arduino-cli compile -b arduino:avr:nano --build-property "build.extra_flags=-DROTATE_PANEL" <Sketch>
+```
+
 **Download the latest release.**
 
 [TODO]

--- a/README.md
+++ b/README.md
@@ -22,18 +22,6 @@ section of the Arduino Sketch Specification.
 git submodule add https://github.com/awonak/libmodulove.git <sketch>/src/libmodulove
 ```
 
-**Supported build flags.**
-
-`ENCODER_REVERSED` - Reverse the direction of the rotary encoder.
-
-`ROTATE_PANEL` - Rotate the orientation of the OLED by 180 degrees and swap the CLK and RST input jacks.
-
-Example usage:
-
-```shell
-arduino-cli compile -b arduino:avr:nano --build-property "build.extra_flags=-DROTATE_PANEL" <Sketch>
-```
-
 **Download the latest release.**
 
 [TODO]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Arythmatik hw;
 byte counter = 0;
 
 void setup() {
+    // Inside the setup, set config values prior to calling hw.Init().
+    #ifdef ROTATE_PANEL
+        hw.config.RotatePanel = true;
+    #endif
+
+    #ifdef REVERSE_ENCODER
+        hw.config.ReverseEncoder = true;
+    #endif
+
     // Initialize the A-RYTH-MATIK peripherials.
     hw.Init();
 }

--- a/arythmatik.cpp
+++ b/arythmatik.cpp
@@ -4,9 +4,9 @@
  * @brief Library for building custom scripts for Modulove modules.
  * @version 0.2
  * @date 2023-09-06
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 
 #include "arythmatik.h"
@@ -29,6 +29,9 @@ void Arythmatik::InitDisplay() {
     display.clearDisplay();
     display.setTextSize(1);
     display.setTextColor(WHITE);
+#ifdef ROTATE_PANEL
+    display.setRotation(2);  // 180 degree rotation for upside-down use
+#endif
     display.display();
 }
 
@@ -36,7 +39,6 @@ void Arythmatik::InitInputs() {
     clk.Init(CLK_PIN);
     rst.Init(RST_PIN);
 }
-
 
 void Arythmatik::InitOutputs() {
     // Initialize each of the outputs with it's GPIO pins and probability.

--- a/arythmatik.cpp
+++ b/arythmatik.cpp
@@ -54,12 +54,21 @@ void Arythmatik::InitInputs() {
 
 void Arythmatik::InitOutputs() {
     // Initialize each of the outputs with it's GPIO pins and probability.
-    outputs[0].Init(OUT_CH1, LED_CH1);
-    outputs[1].Init(OUT_CH2, LED_CH2);
-    outputs[2].Init(OUT_CH3, LED_CH3);
-    outputs[3].Init(OUT_CH4, LED_CH4);
-    outputs[4].Init(OUT_CH5, LED_CH5);
-    outputs[5].Init(OUT_CH6, LED_CH6);
+    if (config.RotatePanel) {
+        outputs[0].Init(OUT_CH1_ROTATED, LED_CH1_ROTATED);
+        outputs[1].Init(OUT_CH2_ROTATED, LED_CH2_ROTATED);
+        outputs[2].Init(OUT_CH3_ROTATED, LED_CH3_ROTATED);
+        outputs[3].Init(OUT_CH4_ROTATED, LED_CH4_ROTATED);
+        outputs[4].Init(OUT_CH5_ROTATED, LED_CH5_ROTATED);
+        outputs[5].Init(OUT_CH6_ROTATED, LED_CH6_ROTATED);
+    } else {
+        outputs[0].Init(OUT_CH1, LED_CH1);
+        outputs[1].Init(OUT_CH2, LED_CH2);
+        outputs[2].Init(OUT_CH3, LED_CH3);
+        outputs[3].Init(OUT_CH4, LED_CH4);
+        outputs[4].Init(OUT_CH5, LED_CH5);
+        outputs[5].Init(OUT_CH6, LED_CH6);
+    }
 }
 
 void Arythmatik::ProcessInputs() {

--- a/arythmatik.cpp
+++ b/arythmatik.cpp
@@ -12,35 +12,41 @@
 #include "arythmatik.h"
 
 using namespace modulove;
+using namespace arythmatik;
 
-void Arythmatik::Init() {
-    InitInputs();
-    InitOutputs();
-    InitDisplay();
+void Arythmatik::Init(Config config) {
+    InitInputs(config);
+    InitOutputs(config);
+    InitDisplay(config);
 
     // CLOCK LED (DIGITAL)
     pinMode(CLOCK_LED, OUTPUT);
 }
 
-void Arythmatik::InitDisplay() {
+void Arythmatik::InitDisplay(Config config) {
     // OLED Display configuration.
     display.begin(SSD1306_SWITCHCAPVCC, OLED_ADDRESS);
     delay(1000);
     display.clearDisplay();
     display.setTextSize(1);
     display.setTextColor(WHITE);
-#ifdef ROTATE_PANEL
-    display.setRotation(2);  // 180 degree rotation for upside-down use
-#endif
     display.display();
+    (config.RotatePanel)
+        ? display.setRotation(2)   // 180 degree rotation for upside-down use
+        : display.setRotation(0);  // Default oled orientation.
 }
 
-void Arythmatik::InitInputs() {
-    clk.Init(CLK_PIN);
-    rst.Init(RST_PIN);
+void Arythmatik::InitInputs(Config config) {
+    if (config.RotatePanel) {
+        clk.Init(CLK_PIN_ROTATED);
+        rst.Init(RST_PIN_ROTATED);
+    } else {
+        clk.Init(CLK_PIN);
+        rst.Init(RST_PIN);
+    }
 }
 
-void Arythmatik::InitOutputs() {
+void Arythmatik::InitOutputs(Config config) {
     // Initialize each of the outputs with it's GPIO pins and probability.
     outputs[0].Init(OUT_CH1, LED_CH1);
     outputs[1].Init(OUT_CH2, LED_CH2);

--- a/arythmatik.cpp
+++ b/arythmatik.cpp
@@ -29,10 +29,10 @@ void Arythmatik::InitDisplay() {
     display.clearDisplay();
     display.setTextSize(1);
     display.setTextColor(WHITE);
-#ifdef ROTATE_PANEL
-    display.setRotation(2);  // 180 degree rotation for upside-down use
-#endif
     display.display();
+#ifdef ROTATE_PANEL
+    display.setRotation(2);
+#endif
 }
 
 void Arythmatik::InitInputs() {

--- a/arythmatik.cpp
+++ b/arythmatik.cpp
@@ -14,16 +14,16 @@
 using namespace modulove;
 using namespace arythmatik;
 
-void Arythmatik::Init(Config config) {
-    InitInputs(config);
-    InitOutputs(config);
-    InitDisplay(config);
+void Arythmatik::Init() {
+    InitInputs();
+    InitOutputs();
+    InitDisplay();
 
     // CLOCK LED (DIGITAL)
     pinMode(CLOCK_LED, OUTPUT);
 }
 
-void Arythmatik::InitDisplay(Config config) {
+void Arythmatik::InitDisplay() {
     // OLED Display configuration.
     display.begin(SSD1306_SWITCHCAPVCC, OLED_ADDRESS);
     delay(1000);
@@ -36,7 +36,8 @@ void Arythmatik::InitDisplay(Config config) {
         : display.setRotation(0);  // Default oled orientation.
 }
 
-void Arythmatik::InitInputs(Config config) {
+void Arythmatik::InitInputs() {
+    // Set the cv input pins.
     if (config.RotatePanel) {
         clk.Init(CLK_PIN_ROTATED);
         rst.Init(RST_PIN_ROTATED);
@@ -44,9 +45,14 @@ void Arythmatik::InitInputs(Config config) {
         clk.Init(CLK_PIN);
         rst.Init(RST_PIN);
     }
+
+    // Set the encoder direction.
+    if (config.ReverseEncoder) {
+        encoder.setDirection(1);
+    }
 }
 
-void Arythmatik::InitOutputs(Config config) {
+void Arythmatik::InitOutputs() {
     // Initialize each of the outputs with it's GPIO pins and probability.
     outputs[0].Init(OUT_CH1, LED_CH1);
     outputs[1].Init(OUT_CH2, LED_CH2);

--- a/arythmatik.h
+++ b/arythmatik.h
@@ -27,7 +27,7 @@ class Arythmatik {
     ~Arythmatik() {}
 
     // Module configuration storage struct.
-    Config config;
+    arythmatik::Config config;
 
     /// @brief Initializes the Arduino, and A-RYTH-MATIK hardware.
     void Init();

--- a/arythmatik.h
+++ b/arythmatik.h
@@ -9,6 +9,7 @@
 #include <EEPROM.h>
 #include <Wire.h>
 
+#include "arythmatik_config.h"
 #include "arythmatik_peripherials.h"
 #include "digital_input.h"
 #include "digital_output.h"
@@ -27,7 +28,7 @@ class Arythmatik {
     ~Arythmatik() {}
 
     /// @brief Initializes the Arduino, and A-RYTH-MATIK hardware.
-    void Init();
+    void Init(arythmatik::Config config);
 
     /// @brief Read the state of the CLK and RST inputs.
     void ProcessInputs();
@@ -39,9 +40,9 @@ class Arythmatik {
     DigitalInput rst;                                 ///< RST Digital Input object.
 
    private:
-    void InitDisplay();
-    void InitInputs();
-    void InitOutputs();
+    void InitDisplay(arythmatik::Config config);
+    void InitInputs(arythmatik::Config config);
+    void InitOutputs(arythmatik::Config config);
 };
 }  // namespace modulove
 

--- a/arythmatik.h
+++ b/arythmatik.h
@@ -26,6 +26,7 @@ class Arythmatik {
     /// @brief Deconstructor
     ~Arythmatik() {}
 
+    // Module configuration storage struct.
     Config config;
 
     /// @brief Initializes the Arduino, and A-RYTH-MATIK hardware.

--- a/arythmatik.h
+++ b/arythmatik.h
@@ -21,14 +21,15 @@ namespace modulove {
 class Arythmatik {
    public:
     /// @brief Constructor
-    Arythmatik() : 
-      display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1) {}
+    Arythmatik() : display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1) {}
 
     /// @brief Deconstructor
     ~Arythmatik() {}
 
+    Config config;
+
     /// @brief Initializes the Arduino, and A-RYTH-MATIK hardware.
-    void Init(arythmatik::Config config);
+    void Init();
 
     /// @brief Read the state of the CLK and RST inputs.
     void ProcessInputs();
@@ -40,9 +41,9 @@ class Arythmatik {
     DigitalInput rst;                                 ///< RST Digital Input object.
 
    private:
-    void InitDisplay(arythmatik::Config config);
-    void InitInputs(arythmatik::Config config);
-    void InitOutputs(arythmatik::Config config);
+    void InitDisplay();
+    void InitInputs();
+    void InitOutputs();
 };
 }  // namespace modulove
 

--- a/arythmatik_config.h
+++ b/arythmatik_config.h
@@ -4,9 +4,9 @@
  * @brief collection of configuration settings for the A-RYTH-MATIK..
  * @version 0.1
  * @date 2024-05-04
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 #ifndef ARYTHMATIK_CONFIG_H
 #define ARYTHMATIK_CONFIG_H
@@ -14,15 +14,14 @@
 namespace modulove {
 namespace arythmatik {
 
-struct Config
-{
+// Configuration settings for the A-RYTH-MATIK module.
+struct Config {
     // When compiling for the "updside down" A-RYTH-MATIK panel, set this to true.
     bool RotatePanel;
 
     // Set ReverseEncoder to true if rotating the encoder counterclockwise should increment.
     bool ReverseEncoder;
 };
-
 
 }  // namespace arythmatik
 }  // namespace modulove

--- a/arythmatik_config.h
+++ b/arythmatik_config.h
@@ -1,0 +1,30 @@
+/**
+ * @file arythmatik_config.h
+ * @author Adam Wonak (https://github.com/awonak)
+ * @brief collection of configuration settings for the A-RYTH-MATIK..
+ * @version 0.1
+ * @date 2024-05-04
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+#ifndef ARYTHMATIK_CONFIG_H
+#define ARYTHMATIK_CONFIG_H
+
+namespace modulove {
+namespace arythmatik {
+
+struct Config
+{
+    // When compiling for the "updside down" A-RYTH-MATIK panel, set this to true.
+    bool RotatePanel;
+
+    // Set ReverseEncoder to true if rotating the encoder counterclockwise should increment.
+    bool ReverseEncoder;
+};
+
+
+}  // namespace arythmatik
+}  // namespace modulove
+
+#endif

--- a/arythmatik_peripherials.h
+++ b/arythmatik_peripherials.h
@@ -46,6 +46,20 @@ namespace arythmatik {
 #define LED_CH5 1
 #define LED_CH6 17
 
+// Output Pins for rotated panel.
+#define OUT_CH1_ROTATED 8
+#define OUT_CH2_ROTATED 9
+#define OUT_CH3_ROTATED 10
+#define OUT_CH4_ROTATED 1
+#define OUT_CH5_ROTATED 6
+#define OUT_CH6_ROTATED 7
+#define LED_CH1_ROTATED 0
+#define LED_CH2_ROTATED 1
+#define LED_CH3_ROTATED 17
+#define LED_CH4_ROTATED 14
+#define LED_CH5_ROTATED 15
+#define LED_CH6_ROTATED 16
+
 const uint8_t OUTPUT_COUNT = 6;
 
 }  // namespace arythmatik

--- a/arythmatik_peripherials.h
+++ b/arythmatik_peripherials.h
@@ -4,9 +4,9 @@
  * @brief Arduino pin definitions for the Modulove A-RYTH-MATIC module.
  * @version 0.1
  * @date 2023-09-06
- * 
+ *
  * @copyright Copyright (c) 2023
- * 
+ *
  */
 #ifndef ARYTHMATIK_PERIPHERIALS_H
 #define ARYTHMATIK_PERIPHERIALS_H
@@ -23,8 +23,14 @@ namespace arythmatik {
 #define ENCODER_PIN1 2
 #define ENCODER_PIN2 3
 #define ENCODER_SW_PIN 12
+
+#ifdef ROTATE_PANEL
 #define CLK_PIN 13
 #define RST_PIN 11
+#else
+#define CLK_PIN 11
+#define RST_PIN 13
+#endif
 
 // Output Pins
 #define CLOCK_LED 4

--- a/arythmatik_peripherials.h
+++ b/arythmatik_peripherials.h
@@ -24,13 +24,12 @@ namespace arythmatik {
 #define ENCODER_PIN2 3
 #define ENCODER_SW_PIN 12
 
-#ifdef ROTATE_PANEL
-#define CLK_PIN 13
-#define RST_PIN 11
-#else
+// Default panel orientation.
 #define CLK_PIN 11
 #define RST_PIN 13
-#endif
+// Rotated panel.
+#define CLK_PIN_ROTATED 13
+#define RST_PIN_ROTATED 11
 
 // Output Pins
 #define CLOCK_LED 4

--- a/encoder.h
+++ b/encoder.h
@@ -39,19 +39,20 @@ class Encoder {
     Encoder() : encoder_(ENCODER_PIN1, ENCODER_PIN2, ENCODER_SW_PIN) {}
     ~Encoder() {}
 
+    /// @brief Set the encoder direction by passing 0 for cw increment or 1 for ccw increment.
+    void setDirection(byte direction) {
+        reversed_ = direction == 1;
+    }
+
     /// @brief Get the rotary direction if it has turned.
     /// @return Direction of turn or unchanged.
     Direction Rotate() {
-#ifdef ENCODER_REVERSED
-        // Reversed (counter clockwise)
-        return rotate_ccw();
-#else
-        // Default (clockwise)
-        return rotate_cw();
-#endif
+        return (reversed_)
+                   ? rotate_reversed()
+                   : rotate();
     }
 
-    Direction rotate_cw() {
+    Direction rotate() {
         switch (encoder_.rotate()) {
             case 1:
                 return DIRECTION_INCREMENT;
@@ -62,7 +63,7 @@ class Encoder {
         }
     }
 
-    Direction rotate_ccw() {
+    Direction rotate_reversed() {
         switch (encoder_.rotate()) {
             case 1:
                 return DIRECTION_DECREMENT;
@@ -98,6 +99,7 @@ class Encoder {
    private:
     SimpleRotary encoder_;
     static const int LONG_PRESS_DURATION_MS = 1000;
+    byte reversed_ = 0;
 
     byte _press() {
         // Check for long press to endable editing seed.


### PR DESCRIPTION
~~One caveat with this implementation is that the ROTATE_PANEL is used in the arythmatik.cpp source file, not the header file, so adding #define ROTATE_PANEL in the .ino filea .ino sketch is not enough to make it visible at compile time. To properly compile the sketch with the flag visible to the library, it must be compiled with the flag set as a build property:~~

~~arduino-cli compile -b lgt8fx:avr:328 --build-property "build.extra_flags=-DROTATE_PANEL" BitGarden.ino -u -p /dev/ttyUSB0~~

UPDATE:

Added a struct with configuration settings for changing the behavior of the A-RYTH-MATIK module.

```c
// Configuration settings for the A-RYTH-MATIK module.
struct Config {
    // When compiling for the "updside down" A-RYTH-MATIK panel, set this to true.
    bool RotatePanel;

    // Set ReverseEncoder to true if rotating the encoder counterclockwise should increment.
    bool ReverseEncoder;
};
```

The config values can be set in the sketch's `setup()` method by checking preproc build flags:
```c
// Declare A-RYTH-MATIK hardware variable.
Arythmatik hw;

setup() {
  #ifdef ROTATE_PANEL
      hw.config.RotatePanel = true;
  #endif
  
  #ifdef REVERSE_ENCODER
      hw.config.ReverseEncoder = true;
  #endif
  ...
  hw.Init();
  ...
}
```